### PR TITLE
rePutField

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ Can be used for the VAL field. Example:
     ABC:Z
 
     epics> rePutField "(.*):.*" "EGU" "units"
-    ABC:X: added field(EGU, 'units')
-    ABC:Y: added field(EGU, 'units')
-    ABC:Z: added field(EGU, 'units')
+    ABC:X: put field(EGU, 'units')
+    ABC:Y: put field(EGU, 'units')
+    ABC:Z: put field(EGU, 'units')
 
     epics> dbDumpRecord
     record(ai,"ABC:X") {

--- a/README.md
+++ b/README.md
@@ -84,6 +84,35 @@ Matching groups can be used for `value`. Example:
         info("prefix","ABC")
     }
 
+#### `rePutField "pattern" "field" "value"`
+
+Sets the value of a particular field to all records that match the regular expression in `pattern`.
+Can be used for the VAL field. Example:
+
+    epics> dbl
+    ABC:X
+    ABC:Y
+    ABC:Z
+
+    epics> rePutField "(.*):.*" "EGU" "units"
+    ABC:X: added field(EGU, 'units')
+    ABC:Y: added field(EGU, 'units')
+    ABC:Z: added field(EGU, "units')
+
+    epics> dbDumpRecord
+    record(ai,"ABC:X") {
+        field(DTYP,"Soft Channel")
+        field(EGU,"units")
+    }
+    record(ai,"ABC:Y") {
+        field(DTYP,"Soft Channel")
+        field(EGU,"units")
+    }
+    record(ai,"ABC:Z") {
+        field(DTYP,"Soft Channel")
+        field(EGU,"units")
+    }
+
 ### Disabling verbose output
 
 By default, retools has verbose output. To disable it, set the variable

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Can be used for the VAL field. Example:
     epics> rePutField "(.*):.*" "EGU" "units"
     ABC:X: added field(EGU, 'units')
     ABC:Y: added field(EGU, 'units')
-    ABC:Z: added field(EGU, "units')
+    ABC:Z: added field(EGU, 'units')
 
     epics> dbDumpRecord
     record(ai,"ABC:X") {

--- a/retoolsApp/src/retools.cpp
+++ b/retoolsApp/src/retools.cpp
@@ -193,11 +193,25 @@ static void reAddInfoCallFunc(const iocshArgBuf *args) {
     reAddInfo(args[0].sval, args[1].sval, args[2].sval);
 }
 
+static const iocshArg rePutFieldArg0 = { "pattern", iocshArgString };
+static const iocshArg rePutFieldArg1 = { "name", iocshArgString };
+static const iocshArg rePutFieldArg2 = { "value", iocshArgString };
+static const iocshArg * const rePutFieldArgs[3] = {
+    &rePutFieldArg0, &rePutFieldArg1, &rePutFieldArg2
+};
+static const iocshFuncDef rePutFieldFuncDef = { "rePutField", 3, rePutFieldArgs };
+
+static void rePutFieldCallFunc(const iocshArgBuf *args) {
+    rePutField(args[0].sval, args[1].sval, args[2].sval);
+}
+
+
 static void retools_registrar(void) {
     iocshRegister(&reGrepFuncDef, reGrepCallFunc);
     iocshRegister(&reTestFuncDef, reTestCallFunc);
     iocshRegister(&reAddAliasFuncDef, reAddAliasCallFunc);
     iocshRegister(&reAddInfoFuncDef, reAddInfoCallFunc);
+    iocshRegister(&rePutFieldFuncDef, rePutFieldCallFunc);
 }
 
 #include <epicsExport.h>

--- a/retoolsApp/src/retools.cpp
+++ b/retoolsApp/src/retools.cpp
@@ -143,7 +143,7 @@ long epicsShareAPI rePutField(const char *pattern, const char *name,
 
     return forEachMatchingRecord(pattern, value,
         [name](DBENTRY *entry, string const & recName, string const & value) {
-            if(dbPutField(entry, name+":"+field, value.c_str()))
+            if(dbPutRecordAttribute(entry, name, value.c_str()))
                 errlogSevPrintf(errlogMajor,
                     "%s: Failed to add info(%s, '%s')\n", recName.c_str(),
                     name, value.c_str());

--- a/retoolsApp/src/retools.cpp
+++ b/retoolsApp/src/retools.cpp
@@ -132,25 +132,24 @@ long epicsShareAPI reAddInfo(const char *pattern, const char *name,
         });
 }
 
-long epicsShareAPI rePutField(const char *pattern, const char *name,
+long epicsShareAPI rePutField(const char *pattern, const char *field,
         const char *value)
 {
-    if (!pattern || !name || !value) {
+    if (!pattern || !field || !value) {
         errlogSevPrintf(errlogMinor,
                 "Usage: %s \"pattern\" \"field\" \"value\"\n", __func__);
         return EXIT_FAILURE;
     }
 
     return forEachMatchingRecord(pattern, value,
-        [name](DBENTRY *entry, string const & recName, string const & value) {
-            string fieldName = recName + "." + name;
-            dbFindField(entry,name);
+        [field](DBENTRY *entry, string const & recName, string const & value) {
+            dbFindField(entry,field);
             if(dbPutString(entry, value.c_str()))
                 errlogSevPrintf(errlogMajor,
-                    "%s: Failed to add info(%s, '%s')\n", recName.c_str(),
-                    name, value.c_str());
+                    "%s: Failed to add field(%s, '%s')\n", recName.c_str(),
+                    field, value.c_str());
             else if(reToolsVerbose)
-                printf("%s: added info(%s, '%s')\n", recName.c_str(), name,
+                printf("%s: added field(%s, '%s')\n", recName.c_str(), field,
                     value.c_str());
         });
 }
@@ -196,7 +195,7 @@ static void reAddInfoCallFunc(const iocshArgBuf *args) {
 }
 
 static const iocshArg rePutFieldArg0 = { "pattern", iocshArgString };
-static const iocshArg rePutFieldArg1 = { "name", iocshArgString };
+static const iocshArg rePutFieldArg1 = { "field", iocshArgString };
 static const iocshArg rePutFieldArg2 = { "value", iocshArgString };
 static const iocshArg * const rePutFieldArgs[3] = {
     &rePutFieldArg0, &rePutFieldArg1, &rePutFieldArg2

--- a/retoolsApp/src/retools.cpp
+++ b/retoolsApp/src/retools.cpp
@@ -143,7 +143,9 @@ long epicsShareAPI rePutField(const char *pattern, const char *name,
 
     return forEachMatchingRecord(pattern, value,
         [name](DBENTRY *entry, string const & recName, string const & value) {
-            if(dbPutRecordAttribute(entry, name, value.c_str()))
+            string fieldName = recName + "." + name;
+            dbFindField(entry,name);
+            if(dbPutString(entry, value.c_str()))
                 errlogSevPrintf(errlogMajor,
                     "%s: Failed to add info(%s, '%s')\n", recName.c_str(),
                     name, value.c_str());

--- a/retoolsApp/src/retools.cpp
+++ b/retoolsApp/src/retools.cpp
@@ -133,11 +133,11 @@ long epicsShareAPI reAddInfo(const char *pattern, const char *name,
 }
 
 long epicsShareAPI rePutField(const char *pattern, const char *name,
-        const char *field, const char *value)
+        const char *value)
 {
-    if (!pattern || !name || !field || !value) {
+    if (!pattern || !name || !value) {
         errlogSevPrintf(errlogMinor,
-                "Usage: %s \"pattern\" \"name\" \"field\" \"value\"\n", __func__);
+                "Usage: %s \"pattern\" \"field\" \"value\"\n", __func__);
         return EXIT_FAILURE;
     }
 

--- a/retoolsApp/src/retools.cpp
+++ b/retoolsApp/src/retools.cpp
@@ -133,17 +133,17 @@ long epicsShareAPI reAddInfo(const char *pattern, const char *name,
 }
 
 long epicsShareAPI rePutField(const char *pattern, const char *name,
-        const char *value)
+        const char *field, const char *value)
 {
-    if (!pattern || !name || !value) {
+    if (!pattern || !name || !field || !value) {
         errlogSevPrintf(errlogMinor,
-                "Usage: %s \"pattern\" \"name\" \"value\"\n", __func__);
+                "Usage: %s \"pattern\" \"name\" \"field\" \"value\"\n", __func__);
         return EXIT_FAILURE;
     }
 
     return forEachMatchingRecord(pattern, value,
         [name](DBENTRY *entry, string const & recName, string const & value) {
-            if(dbPutField(entry, name, value.c_str()))
+            if(dbPutField(entry, name+":"+field, value.c_str()))
                 errlogSevPrintf(errlogMajor,
                     "%s: Failed to add info(%s, '%s')\n", recName.c_str(),
                     name, value.c_str());

--- a/retoolsApp/src/retools.cpp
+++ b/retoolsApp/src/retools.cpp
@@ -132,6 +132,27 @@ long epicsShareAPI reAddInfo(const char *pattern, const char *name,
         });
 }
 
+long epicsShareAPI rePutField(const char *pattern, const char *name,
+        const char *value)
+{
+    if (!pattern || !name || !value) {
+        errlogSevPrintf(errlogMinor,
+                "Usage: %s \"pattern\" \"name\" \"value\"\n", __func__);
+        return EXIT_FAILURE;
+    }
+
+    return forEachMatchingRecord(pattern, value,
+        [name](DBENTRY *entry, string const & recName, string const & value) {
+            if(dbPutField(entry, name, value.c_str()))
+                errlogSevPrintf(errlogMajor,
+                    "%s: Failed to add info(%s, '%s')\n", recName.c_str(),
+                    name, value.c_str());
+            else if(reToolsVerbose)
+                printf("%s: added info(%s, '%s')\n", recName.c_str(), name,
+                    value.c_str());
+        });
+}
+
 
 // EPICS registration code
 static const iocshArg reGrepArg0 = { "pattern", iocshArgString };

--- a/retoolsApp/src/retools.cpp
+++ b/retoolsApp/src/retools.cpp
@@ -142,10 +142,10 @@ long epicsShareAPI rePutField(const char *pattern, const char *field,
 
     return forEachMatchingRecord(pattern, value,
         [field](DBENTRY *entry, string const & recName, string const & value) {
-	    DBADDR addr;
-	    string fieldName = recName + "." + field;
-	    
-	    if(dbNameToAddr(fieldName.c_str(), &addr))
+            DBADDR addr;
+            string fieldName = recName + "." + field;
+
+            if(dbNameToAddr(fieldName.c_str(), &addr))
                 errlogSevPrintf(errlogMajor,
                     "%s: does not possess field %s \n", recName.c_str(),
                     field);

--- a/retoolsApp/src/retools.h
+++ b/retoolsApp/src/retools.h
@@ -11,7 +11,7 @@ epicsShareFunc long reAddAlias(const char *pattern, const char *alias);
 epicsShareFunc long reAddInfo(const char *pattern, const char *name,
         const char *value);
 epicsShareFunc long rePutField(const char *pattern, const char *name,
-        const char *field, const char *value);
+        const char *value);
 
 #ifdef __cplusplus
 }

--- a/retoolsApp/src/retools.h
+++ b/retoolsApp/src/retools.h
@@ -10,7 +10,7 @@ extern "C" {
 epicsShareFunc long reAddAlias(const char *pattern, const char *alias);
 epicsShareFunc long reAddInfo(const char *pattern, const char *name,
         const char *value);
-epicsShareFunc long rePutField(const char *pattern, const char *name,
+epicsShareFunc long rePutField(const char *pattern, const char *field,
         const char *value);
 
 #ifdef __cplusplus

--- a/retoolsApp/src/retools.h
+++ b/retoolsApp/src/retools.h
@@ -10,7 +10,7 @@ extern "C" {
 epicsShareFunc long reAddAlias(const char *pattern, const char *alias);
 epicsShareFunc long reAddInfo(const char *pattern, const char *name,
         const char *value);
-epicsShareFunc long reSetField(const char *pattern, const char *name,
+epicsShareFunc long rePutField(const char *pattern, const char *name,
         const char *field, const char *value);
 
 #ifdef __cplusplus

--- a/retoolsApp/src/retools.h
+++ b/retoolsApp/src/retools.h
@@ -11,7 +11,7 @@ epicsShareFunc long reAddAlias(const char *pattern, const char *alias);
 epicsShareFunc long reAddInfo(const char *pattern, const char *name,
         const char *value);
 epicsShareFunc long reSetField(const char *pattern, const char *name,
-        const char *value);
+        const char *field, const char *value);
 
 #ifdef __cplusplus
 }

--- a/retoolsApp/src/retools.h
+++ b/retoolsApp/src/retools.h
@@ -10,6 +10,8 @@ extern "C" {
 epicsShareFunc long reAddAlias(const char *pattern, const char *alias);
 epicsShareFunc long reAddInfo(const char *pattern, const char *name,
         const char *value);
+epicsShareFunc long reSetField(const char *pattern, const char *name,
+        const char *value);
 
 #ifdef __cplusplus
 }

--- a/testApp/test.c
+++ b/testApp/test.c
@@ -117,7 +117,7 @@ static void test_rePutField(void)
     testOk1(!rePutField("(.*):B", fieldName, fieldValue));
 
 
-    // Check that all records ending in B had the info tag added
+    // Check that all records ending in B had the EGU field changed to "units"
     const char *fmt = "DIAG_MTCA01:PICO3_CH%d:%s";
     int i = 0;
     for (i = 0; i < 4; ++i) {

--- a/testApp/test.c
+++ b/testApp/test.c
@@ -114,7 +114,7 @@ static void test_rePutField(void)
 
     const char *fieldName = "EGU";
     const char *fieldValue = "units";
-    testOk1(!rePutField("(.*):B", fieldName, fieldMonitor));
+    testOk1(!rePutField("(.*):B", fieldName, fieldValue));
 
 
     // Check that all records ending in B had the info tag added

--- a/testApp/test.c
+++ b/testApp/test.c
@@ -134,7 +134,7 @@ static void test_rePutField(void)
         testOk(found, "%s: field found", name);
 
         if (found) {
-            testOk(!strcmp(fieldName, dbGetString(&entry)),
+            testOk(!strcmp(fieldValue, dbGetString(&entry)),
                     "%s info name is correct", name);
         }
         dbFinishEntry(&entry);

--- a/testApp/test.c
+++ b/testApp/test.c
@@ -135,7 +135,7 @@ static void test_rePutField(void)
 
         if (found) {
             testOk(!strcmp(fieldValue, dbGetString(&entry)),
-                    "%s info name is correct", name);
+                    "%s field value is correct", name);
         }
         dbFinishEntry(&entry);
     }


### PR DESCRIPTION
This PR adds the ability to set fields with retools. My original goal was to be able to set all PVs under a particular pattern to a value (_e.g.,_ set the current of all channels of this power supply to 1mA with `rePutField .*CurrentSet VAL 0.001`), but with the power of REGEXes, you can write a DESC field or the EGU field quickly.

It can also be handy when setting st.cmd files, as you can write to the local "PowerOn" PV for each device without having to modify each st.cmd (_e.g.,_ `rePutField .*PowerOn VAL 1`)

Sorry, the commits are a bit messy. If you want, I can create a new branch and squash them before sending a PR.