### PR TITLE
Add less verbose option

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,4 +136,4 @@ By default, retools has verbose output. To disable it, set the variable
     epics> var reToolsVerbose 0
     epics>
 
-You may also set `reToolsVerbose` to `2` so retools only displays the number of record matches found by each function.
+You may also set `reToolsVerbose` to `2` so retools only displays the number of record matches found by each function. The option works as a bit mask, _e.g.,_ setting it to `3` would enable both the total number of matches and the default verbose output.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Can be used for the VAL field. Example:
         field(EGU,"units")
     }
 
-### Disabling verbose output
+### Adjusting output verbosity
 
 By default, retools has verbose output. To disable it, set the variable
 `reToolsVerbose` to `0`:
@@ -121,3 +121,4 @@ By default, retools has verbose output. To disable it, set the variable
     epics> var reToolsVerbose 0
     epics>
 
+You may also set `reToolsVerbose` to `2` so retools only displays the number of record matches found by each function.

--- a/retoolsApp/src/retools.cpp
+++ b/retoolsApp/src/retools.cpp
@@ -34,6 +34,7 @@ int forEachMatchingRecord(string const & pattern, string const & replace,
     dbInitEntry(pdbbase, &_entry);
 
     long _status = dbFirstRecordType(&_entry);
+    unsigned int n_records = 0;
 
     while (!_status) {
         _status = dbFirstRecord(&_entry);
@@ -54,6 +55,8 @@ int forEachMatchingRecord(string const & pattern, string const & replace,
 
                 func(&entry, recName, regex_replace(recName, re, replace));
                 dbFinishEntry(&entry);
+                // Count how many matches
+                n_records++;
             }
 
             _status = dbNextRecord(&_entry);
@@ -61,6 +64,9 @@ int forEachMatchingRecord(string const & pattern, string const & replace,
         _status = dbNextRecordType(&_entry);
     }
     dbFinishEntry(&_entry);
+    // If desired, display total of records processed
+    if(reToolsVerbose==2)
+        printf("Total matches: %u\n", n_records);
     return EXIT_SUCCESS;
 }
 
@@ -104,7 +110,7 @@ long epicsShareAPI reAddAlias(const char *pattern, const char *alias)
             if(dbCreateAlias(entry, alias.c_str()))
                 errlogSevPrintf(errlogMinor, "Failed to alias %s -> %s\n",
                     recName.c_str(), alias.c_str());
-            else if(reToolsVerbose)
+            else if(reToolsVerbose==1)
                 printf("Alias %s -> %s created\n", recName.c_str(),
                     alias.c_str());
         });

--- a/retoolsApp/src/retools.cpp
+++ b/retoolsApp/src/retools.cpp
@@ -13,6 +13,9 @@ using std::regex_replace;
 using std::regex_error;
 using std::string;
 
+#define VERBOSE_EACH_ALIAS  (1<<0)
+#define VERBOSE_PRINT_TOTAL (1<<1)
+
 int reToolsVerbose = 1;
 
 typedef std::function<void(DBENTRY*,string const &,string const &)>
@@ -66,7 +69,7 @@ int forEachMatchingRecord(string const & pattern, string const & replace,
     }
     dbFinishEntry(&_entry);
     // If desired, display total of records processed
-    if(reToolsVerbose==2)
+    if(reToolsVerbose & VERBOSE_PRINT_TOTAL)
         printf("Total matches: %u\n", n_records);
     return EXIT_SUCCESS;
 }
@@ -112,7 +115,7 @@ long epicsShareAPI reAddAlias(const char *pattern, const char *alias)
                 errlogSevPrintf(errlogMinor, "Failed to alias %s -> %s\n",
                     recName.c_str(), alias.c_str());
 
-            else if(reToolsVerbose==1)
+            else if(reToolsVerbose & VERBOSE_EACH_ALIAS)
                 fprintf(epicsGetStdout(),"Alias %s -> %s created\n", recName.c_str(),
                     alias.c_str());
         });


### PR DESCRIPTION
Inspired by #3. I lack the ability to do it elegantly for just reAddAlias, but I think it might make most sense this way.

I wonder if it would be adequate to set some kind of binary masking, so `reToolsVerbose=3` would include both the total and each of the processed records.