### PR TITLE
reGetField

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,21 @@ Can be used for the VAL field. Example:
         field(EGU,"units")
     }
 
+#### `reGetField "pattern" "field"`
+
+Gets the value of a particular field to all records that match the regular expression in `pattern`.
+Can be used for the VAL field. Example:
+
+    epics> dbl
+    ABC:X
+    ABC:Y
+    ABC:Z
+
+    epics> reGetField "(.*):.*" "EGU"
+    ABC:X 'units'
+    ABC:Y 'units'
+    ABC:Z 'units'
+
 ### Disabling verbose output
 
 By default, retools has verbose output. To disable it, set the variable

--- a/retoolsApp/src/retools.cpp
+++ b/retoolsApp/src/retools.cpp
@@ -4,6 +4,7 @@
 #include <errlog.h>
 #include <dbStaticLib.h>
 #include <dbAccessDefs.h>
+#include <epicsStdio.h>
 #include <functional>
 #include <regex>
 
@@ -73,7 +74,7 @@ long epicsShareAPI reGrep(const char *pattern)
 
     return forEachMatchingRecord(pattern, "",
         [](DBENTRY *entry, string const & recName, string const & value) {
-            printf("%s\n", recName.c_str());
+            fprintf(epicsGetStdout(),"%s\n", recName.c_str());
         });
 }
 
@@ -87,7 +88,7 @@ long epicsShareAPI reTest(const char *pattern, const char *value)
 
     return forEachMatchingRecord(pattern, value,
         [](DBENTRY *entry, string const & recName, string const & value) {
-            printf("%s\t%s\n", recName.c_str(), value.c_str());
+            fprintf(epicsGetStdout(),"%s\t%s\n", recName.c_str(), value.c_str());
         });
 }
 
@@ -105,7 +106,7 @@ long epicsShareAPI reAddAlias(const char *pattern, const char *alias)
                 errlogSevPrintf(errlogMinor, "Failed to alias %s -> %s\n",
                     recName.c_str(), alias.c_str());
             else if(reToolsVerbose)
-                printf("Alias %s -> %s created\n", recName.c_str(),
+                fprintf(epicsGetStdout(),"Alias %s -> %s created\n", recName.c_str(),
                     alias.c_str());
         });
 }
@@ -126,7 +127,7 @@ long epicsShareAPI reAddInfo(const char *pattern, const char *name,
                     "%s: Failed to add info(%s, '%s')\n", recName.c_str(),
                     name, value.c_str());
             else if(reToolsVerbose)
-                printf("%s: added info(%s, '%s')\n", recName.c_str(), name,
+                fprintf(epicsGetStdout(),"%s: added info(%s, '%s')\n", recName.c_str(), name,
                     value.c_str());
         });
 }
@@ -154,7 +155,7 @@ long epicsShareAPI rePutField(const char *pattern, const char *field,
                     "%s: Failed to put field(%s, '%s')\n", recName.c_str(),
                     field, value.c_str());
             else if(reToolsVerbose)
-                printf("%s: put field(%s, '%s')\n", recName.c_str(), field,
+                fprintf(epicsGetStdout(),"%s: put field(%s, '%s')\n", recName.c_str(), field,
                     value.c_str());
         });
 }
@@ -183,7 +184,7 @@ long epicsShareAPI reGetField(const char *pattern, const char *field)
                     "%s: Failed to get field %s\n", recName.c_str(),
                     field);
             else{
-                printf("%s.%s '%s'\n", recName.c_str(), field, buffer);
+                fprintf(epicsGetStdout(),"%s.%s '%s'\n", recName.c_str(), field, buffer);
                 }
         });
 }

--- a/retoolsApp/src/retools.h
+++ b/retoolsApp/src/retools.h
@@ -12,6 +12,7 @@ epicsShareFunc long reAddInfo(const char *pattern, const char *name,
         const char *value);
 epicsShareFunc long rePutField(const char *pattern, const char *field,
         const char *value);
+epicsShareFunc long reGetField(const char *pattern, const char *field);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This is the dual to `rePutField`, basically the retools rendition of `dbgf`. The idea is to do a long list of `dbgf`s in an IOC programatically.

I didn't create a unit test for it because since it does not really act on the IOC, it should be safe enough for it to fail (like `reTest` and `reGrep`). That said, I also didn't want to change the API much (I'd need to redirect `stdout` to a buffer, to compare the outputs, which meant adding the desired stream as an argument).

That said, I'm open to work on it if you'd prefer that. I just couldn't figure a portable way to redirect `stdout` without changing the API.